### PR TITLE
Fix 403 Forbidden error and improve application robustness

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -157,7 +157,7 @@ class YouTubeDownloaderGUI:
                 self.video_info = self.downloader.get_video_info(url)
                 
                 if self.video_info:
-                    self.available_qualities = self.downloader.get_available_qualities(url)
+                    self.available_qualities = self.downloader.get_available_qualities(self.video_info)
                     
                     self.root.after(0, self.update_video_info)
                 else:


### PR DESCRIPTION
This commit addresses a "403: Forbidden" error that occurred when fetching video information from YouTube. It also includes several improvements to the application's efficiency and error handling.

The key changes are:

- **Fix 403 Forbidden Error:** A `User-Agent` and other HTTP headers are now included in requests to YouTube, making them appear as if they are coming from a standard web browser. This resolves the 403 error.

- **Improve Efficiency:** The code has been refactored to eliminate a redundant API call that was being made when fetching video information. This makes the application faster and reduces the number of requests sent to YouTube.

- **Enhance Error Handling:** The application now specifically catches `yt-dlp`'s `DownloadError`, which will provide better diagnostics if future issues arise.

- **Add .gitignore:** A `.gitignore` file has been added to the repository to prevent compiled Python files and other unnecessary artifacts from being committed.